### PR TITLE
Fix bug in userpass spray

### DIFF
--- a/credmaster.py
+++ b/credmaster.py
@@ -433,7 +433,7 @@ def load_credentials(user_file, password, userenum, useragent_file=None, userpas
 
 		if userpass != None:
 			password = ":".join(user.split(':')[1:]).strip()
-			username = user.split(':')[0].strip()
+			user = user.split(':')[0].strip()
 
 		cred = {}
 		cred['username'] = user


### PR DESCRIPTION
there's a typo in the userpass spray section that is causing credentials to be sprayed as username:password:password (with the first colon being a literal colon instead of a delimiter) when read from a userpass file

this appears to fix it