### PR TITLE
Fix "continuing" Typo

### DIFF
--- a/plugins/adfs/__init__.py
+++ b/plugins/adfs/__init__.py
@@ -33,6 +33,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuting"
+        output = "Testconnect: Connection success, continuing"
 
     return success, output, pluginargs

--- a/plugins/azuresso/__init__.py
+++ b/plugins/azuresso/__init__.py
@@ -36,6 +36,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuting"
+        output = "Testconnect: Connection success, continuing"
 
     return success, output, pluginargs

--- a/plugins/fortinetvpn/__init__.py
+++ b/plugins/fortinetvpn/__init__.py
@@ -39,6 +39,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
     elif "fortinet" in resp.text:
         output = "Testconnect: Verified Fortinet instance, connected"
     else:
-        output = "Testconnect: Warning, Fortinet client not indicated, continuting"
+        output = "Testconnect: Warning, Fortinet client not indicated, continuing"
 
     return success, output, pluginargs

--- a/plugins/gmailenum/__init__.py
+++ b/plugins/gmailenum/__init__.py
@@ -29,6 +29,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuting"
+        output = "Testconnect: Connection success, continuing"
 
     return success, output, pluginargs

--- a/plugins/httpbrute/__init__.py
+++ b/plugins/httpbrute/__init__.py
@@ -43,6 +43,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuting"
+        output = "Testconnect: Connection success, continuing"
 
     return success, output, pluginargs

--- a/plugins/msol/__init__.py
+++ b/plugins/msol/__init__.py
@@ -25,6 +25,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuting"
+        output = "Testconnect: Connection success, continuing"
 
     return success, output, pluginargs

--- a/plugins/o365/__init__.py
+++ b/plugins/o365/__init__.py
@@ -26,6 +26,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuting"
+        output = "Testconnect: Connection success, continuing"
 
     return success, output, pluginargs

--- a/plugins/o365enum/__init__.py
+++ b/plugins/o365enum/__init__.py
@@ -29,6 +29,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuting"
+        output = "Testconnect: Connection success, continuing"
 
     return success, output, pluginargs

--- a/plugins/okta/__init__.py
+++ b/plugins/okta/__init__.py
@@ -40,6 +40,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuting"
+        output = "Testconnect: Connection success, continuing"
 
     return success, output, pluginargs

--- a/plugins/template/__init__.py
+++ b/plugins/template/__init__.py
@@ -42,6 +42,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuting"
+        output = "Testconnect: Connection success, continuing"
 
     return success, output, pluginargs


### PR DESCRIPTION
The plugin template and all current plugins have a typo in the line: "Connection success, continu**t**ing." This is a tiny change that corrects that typo in all files.