### PR TITLE
Fixed error to include specified region when creating FireProx APIs

### DIFF
--- a/credmaster.py
+++ b/credmaster.py
@@ -233,7 +233,7 @@ class CredMaster(object):
 
 		try:
 			# Create lambdas based on thread count
-			self.load_apis(url)
+			self.load_apis(url, region = self.region)
 
 			# do test connection / fingerprint
 			useragent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"


### PR DESCRIPTION
In my testing it appears that the specified region (either on the command line or in the config file) is not used to create the FireProx APIs. Seems the corresponding argument is not passed to the creating function.