### PR TITLE
Re-add region setting in API creation

### DIFF
--- a/credmaster.py
+++ b/credmaster.py
@@ -233,7 +233,7 @@ class CredMaster(object):
 
 		try:
 			# Create lambdas based on thread count
-			self.load_apis(url)
+			self.load_apis(url, self.region)
 
 			# do test connection / fingerprint
 			useragent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"


### PR DESCRIPTION
Somwhere in refactoring the 'specify region' setting broke. This small commit fixes the region argument.