### PR TITLE
Fixing unbound variable declaration + better notifications

### DIFF
--- a/utils/notify.py
+++ b/utils/notify.py
@@ -1,9 +1,11 @@
 import requests, json
 from datetime import datetime
+from discordwebhook import Discord
 
 def notify_success(username, password, notify_obj):
 
     slack_webhook = notify_obj['slack_webhook']
+    discord_webhook = notify_obj['discord_webhook']
     teams_webhook = notify_obj['teams_webhook']
     pushover_token = notify_obj['pushover_token']
     pushover_user = notify_obj['pushover_user']
@@ -17,6 +19,9 @@ def notify_success(username, password, notify_obj):
     if pushover_token is not None and pushover_user is not None:
         pushover_notify(username, password, operator, exclude_password, pushover_token, pushover_user)
 
+    if discord_webhook is not None:
+        discord_notify(username, password, operator, exclude_password, discord_webhook)
+
     if teams_webhook is not None:
         teams_notify(username, password, operator, exclude_password, teams_webhook)
 
@@ -27,6 +32,7 @@ def notify_success(username, password, notify_obj):
 def notify_update(message, notify_obj):
 
     slack_webhook = notify_obj['slack_webhook']
+    discord_webhook = notify_obj['discord_webhook']
     teams_webhook = notify_obj['teams_webhook']
     pushover_token = notify_obj['pushover_token']
     pushover_user = notify_obj['pushover_user']
@@ -38,6 +44,9 @@ def notify_update(message, notify_obj):
 
     if pushover_token is not None and pushover_user is not None:
         pushover_update(message, operator, pushover_token, pushover_user)
+
+    if discord_webhook is not None:
+        discord_update(message, operator, discord_webhook)
 
     if teams_webhook is not None:
         teams_update(message, operator, teams_webhook)
@@ -180,6 +189,54 @@ def slack_update(message, operator, webhook):
     else:
         print('Notification attempt to Slack failed.')
         print('Error:', response.text)
+
+
+# Function for posting username/password to Discord
+def discord_notify(username, password, operator, exclude_password, webhook):
+
+    now = datetime.now()
+    date=now.strftime("%d-%m-%Y")
+    time=now.strftime("%H:%M:%S")
+
+    op_insert = ""
+    if operator is not None:
+        op_insert = f"Operator: {operator}\n"
+
+    pwd_insert = f"Pass: {password}\n"
+    if exclude_password:
+        pwd_insert = ""
+
+    text = ("```[Valid Credentials Obtained!]\n"
+            f"{op_insert}"
+            f"User: {username}\n"
+            f"{pwd_insert}"
+            f"Date: {date}\n"
+            f"Time: {time}```")
+
+    discord = Discord(url=webhook)
+    discord.post(content=text)
+
+
+# Discord notify message
+def discord_update(message, operator, webhook):
+
+    now = datetime.now()
+    date=now.strftime("%d-%m-%Y")
+    time=now.strftime("%H:%M:%S")
+
+    op_insert = ""
+    if operator is not None:
+        op_insert = f"Operator: {operator}\n"
+
+    text = ("```[Log Entry]\n"
+            f"{op_insert}"
+            f"{message}\n"
+            f"Date: {date}\n"
+            f"Time: {time}```")
+
+    discord = Discord(url=webhook)
+    discord.post(content=text)
+
 
 # Teams notify function
 def teams_notify(username, password, operator, exclude_password, webhook):

--- a/utils/notify.py
+++ b/utils/notify.py
@@ -1,12 +1,9 @@
 import requests, json
 from datetime import datetime
-from discordwebhook import Discord
-
 
 def notify_success(username, password, notify_obj):
 
     slack_webhook = notify_obj['slack_webhook']
-    discord_webhook = notify_obj['discord_webhook']
     teams_webhook = notify_obj['teams_webhook']
     pushover_token = notify_obj['pushover_token']
     pushover_user = notify_obj['pushover_user']
@@ -20,9 +17,6 @@ def notify_success(username, password, notify_obj):
     if pushover_token is not None and pushover_user is not None:
         pushover_notify(username, password, operator, exclude_password, pushover_token, pushover_user)
 
-    if discord_webhook is not None:
-        discord_notify(username, password, operator, exclude_password, discord_webhook)
-
     if teams_webhook is not None:
         teams_notify(username, password, operator, exclude_password, teams_webhook)
 
@@ -33,7 +27,6 @@ def notify_success(username, password, notify_obj):
 def notify_update(message, notify_obj):
 
     slack_webhook = notify_obj['slack_webhook']
-    discord_webhook = notify_obj['discord_webhook']
     teams_webhook = notify_obj['teams_webhook']
     pushover_token = notify_obj['pushover_token']
     pushover_user = notify_obj['pushover_user']
@@ -46,12 +39,9 @@ def notify_update(message, notify_obj):
     if pushover_token is not None and pushover_user is not None:
         pushover_update(message, operator, pushover_token, pushover_user)
 
-    if discord_webhook is not None:
-        discord_update(message, operator, discord_webhook)
-
     if teams_webhook is not None:
         teams_update(message, operator, teams_webhook)
-    
+
     if keybase_webhook is not None:
         keybase_update(message, operator, keybase_webhook)
 
@@ -71,12 +61,12 @@ def keybase_notify(username, password, operator, exclude_password, webhook):
     if exclude_password:
         pwd_insert = ""
 
-    text = ("```[Valid Credentials Obtained!]\n"
-            f"{op_insert}"
-            f"User: {username}\n"
-            f"{pwd_insert}"
-            f"Date: {date}\n"
-            f"Time: {time}```")
+    text = "```[Valid Credentials Obtained!]\n" + \
+            f"{op_insert}" + \
+            f"User: {username}\n" + \
+            f"{pwd_insert}" + \
+            f"Date: {date}\n" + \
+            f"Time: {time}```"
 
     message = {
         "msg" : text
@@ -86,6 +76,11 @@ def keybase_notify(username, password, operator, exclude_password, webhook):
         webhook, data=json.dumps(message),
         headers={'Content-Type': 'application/json'}
     )
+    if response.status_code == 200:
+        print('Notification successfully sent to Keybase.')
+    else:
+        print('Notification attempt to Keybase failed.')
+        print('Error:', response.text)
 
 
 # Function for debug messages
@@ -99,11 +94,11 @@ def keybase_update(message, operator, webhook):
     if operator is not None:
         op_insert = f"Operator: {operator}\n"
 
-    text = ("```[Log Entry]\n"
-            f"{op_insert}"
-            f"{message}\n"
-            f"Date: {date}\n"
-            f"Time: {time}```")
+    text = "```[Log Entry]\n" + \
+            f"{op_insert}" + \
+            f"{message}\n" + \
+            f"Date: {date}\n" + \
+            f"Time: {time}```"
 
     message = {
         "msg" : text
@@ -112,7 +107,11 @@ def keybase_update(message, operator, webhook):
         webhook, data=json.dumps(message),
         headers={'Content-Type': 'application/json'}
     )
-
+    if response.status_code == 200:
+        print('Notification successfully sent to Keybase.')
+    else:
+        print('Notification attempt to Keybase failed.')
+        print('Error:', response.text)
 
 
 # Function for posting username/password to slack channel
@@ -130,12 +129,12 @@ def slack_notify(username, password, operator, exclude_password, webhook):
     if exclude_password:
         pwd_insert = ""
 
-    text = ("```[Valid Credentials Obtained!]\n"
-            f"{op_insert}"
-            f"User: {username}\n"
-            f"{pwd_insert}"
-            f"Date: {date}\n"
-            f"Time: {time}```")
+    text = "```[Valid Credentials Obtained!]\n" + \
+            f"{op_insert}" + \
+            f"User: {username}\n" + \
+            f"{pwd_insert}" + \
+            f"Date: {date}\n" + \
+            f"Time: {time}```"
 
     message = {
         "text" : text
@@ -145,6 +144,11 @@ def slack_notify(username, password, operator, exclude_password, webhook):
         webhook, data=json.dumps(message),
         headers={'Content-Type': 'application/json'}
     )
+    if response.status_code == 200:
+        print('Notification successfully sent to Slack.')
+    else:
+        print('Notification attempt to Slack failed.')
+        print('Error:', response.text)
 
 
 # Function for debug messages
@@ -158,11 +162,11 @@ def slack_update(message, operator, webhook):
     if operator is not None:
         op_insert = f"Operator: {operator}\n"
 
-    text = ("```[Log Entry]\n"
-            f"{op_insert}"
-            f"{message}\n"
-            f"Date: {date}\n"
-            f"Time: {time}```")
+    text = "```[Log Entry]\n" + \
+            f"{op_insert}" + \
+            f"{message}\n" + \
+            f"Date: {date}\n" + \
+            f"Time: {time}```"
 
     message = {
         "text" : text
@@ -171,54 +175,11 @@ def slack_update(message, operator, webhook):
         webhook, data=json.dumps(message),
         headers={'Content-Type': 'application/json'}
     )
-
-
-# Function for posting username/password to Discord
-def discord_notify(username, password, operator, exclude_password, webhook):
-
-    now = datetime.now()
-    date=now.strftime("%d-%m-%Y")
-    time=now.strftime("%H:%M:%S")
-
-    op_insert = ""
-    if operator is not None:
-        op_insert = f"Operator: {operator}\n"
-
-    pwd_insert = f"Pass: {password}\n"
-    if exclude_password:
-        pwd_insert = ""
-
-    text = ("```[Valid Credentials Obtained!]\n"
-            f"{op_insert}"
-            f"User: {username}\n"
-            f"{pwd_insert}"
-            f"Date: {date}\n"
-            f"Time: {time}```")
-
-    discord = Discord(url=webhook)
-    discord.post(content=text)
-
-
-# Discord notify message
-def discord_update(message, operator, webhook):
-
-    now = datetime.now()
-    date=now.strftime("%d-%m-%Y")
-    time=now.strftime("%H:%M:%S")
-
-    op_insert = ""
-    if operator is not None:
-        op_insert = f"Operator: {operator}\n"
-
-    text = ("```[Log Entry]\n"
-            f"{op_insert}"
-            f"{message}\n"
-            f"Date: {date}\n"
-            f"Time: {time}```")
-
-    discord = Discord(url=webhook)
-    discord.post(content=text)
-
+    if response.status_code == 200:
+        print('Notification successfully sent to Slack.')
+    else:
+        print('Notification attempt to Slack failed.')
+        print('Error:', response.text)
 
 # Teams notify function
 def teams_notify(username, password, operator, exclude_password, webhook):
@@ -235,14 +196,15 @@ def teams_notify(username, password, operator, exclude_password, webhook):
     if exclude_password:
         pwd_insert = ""
 
+    content = "[Valid Credentials Obtained!]\n" + \
+        f"{op_insert}" + \
+        f"User: {username}\n" + \
+        f"{pwd_insert}" + \
+        f"Date: {date}\n" + \
+        f"Time: {time}"
+
     response = requests.post(
         url=webhook,
-        content = ("[Valid Credentials Obtained!]\n"
-        f"{op_insert}"
-        f"User: {username}\n"
-        f"{pwd_insert}"
-        f"Date: {date}\n"
-        f"Time: {time}"),
         headers={"Content-Type": "application/json"},
         json={
             "summary": "[Valid Credentials Obtained!]",
@@ -252,6 +214,12 @@ def teams_notify(username, password, operator, exclude_password, webhook):
             }],
         },
     )
+    if response.status_code == 200:
+        print('Notification successfully sent to Teams.')
+    else:
+        print('Notification attempt to Teams failed.')
+        print('Error:', response.text)
+
 
 # Teams message notify function
 def teams_update(message, operator, webhook):
@@ -264,13 +232,14 @@ def teams_update(message, operator, webhook):
     if operator is not None:
         op_insert = f"Operator: {operator}\n"
 
+    content = "[Log Entry]\n" + \
+        f"{op_insert}" + \
+        f"Message: {message}\n" + \
+        f"Date: {date}\n" + \
+        f"Time: {time}"
+
     response = requests.post(
         url=webhook,
-        content = ("[Log Entry]\n"
-        f"{op_insert}"
-        f"Message: {message}\n"
-        f"Date: {date}\n"
-        f"Time: {time}"),
         headers={"Content-Type": "application/json"},
         json={
             "summary": "[Log Entry!]",
@@ -280,6 +249,11 @@ def teams_update(message, operator, webhook):
             }],
         },
     )
+    if response.status_code == 200:
+        print('Notification successfully sent to Teams.')
+    else:
+        print('Notification attempt to Teams failed.')
+        print('Error:', response.text)
 
 
 # Pushover notify of valid creds
@@ -299,11 +273,11 @@ def pushover_notify(username, password, operator, exclude_password, token, user)
     if exclude_password:
         pwd_insert = ""
 
-    text = (f"{op_insert}"
-            f"User: {username}\n"
-            f"{pwd_insert}"
-            f"Date: {date}\n"
-            f"Time: {time}")
+    text = f"{op_insert}" + \
+            f"User: {username}\n" + \
+            f"{pwd_insert}" + \
+            f"Date: {date}\n" + \
+            f"Time: {time}"
 
     data = {
         'token' : token,
@@ -314,6 +288,8 @@ def pushover_notify(username, password, operator, exclude_password, token, user)
     }
 
     r = requests.post('https://api.pushover.net/1/messages', headers=headers, data=data)
+    if r.status_code == 200:
+        print('[+] ')
 
 
 # Pushover generic update messages
@@ -329,10 +305,10 @@ def pushover_update(message, operator, token, user):
     if operator is not None:
         op_insert = f"Operator: {operator}\n"
 
-    text = (f"{op_insert}"
-            f"{message}\n"
-            f"Date: {date}\n"
-            f"Time: {time}")
+    text = f"{op_insert}" + \
+            f"{message}\n" + \
+            f"Date: {date}\n" + \
+            f"Time: {time}"
 
     data = {
         'token' : token,
@@ -342,4 +318,13 @@ def pushover_update(message, operator, token, user):
         'message' : text
     }
 
-    r = requests.post('https://api.pushover.net/1/messages', headers=headers, data=data)
+    response = requests.post(
+        'https://api.pushover.net/1/messages',
+        headers=headers,
+        data=data
+    )
+    if response.status_code == 200:
+        print('Notification successfully sent to Pushover.')
+    else:
+        print('Notification attempt to Pushover failed.')
+        print('Error:', response.text)


### PR DESCRIPTION
Addresses:
- extra `content=` parameter in a few `requests.post()` method calls.
- undeclared variable usage
- better notification error handling