### PR TITLE
fix(msol): handle AADSTS50057 error

### DIFF
--- a/plugins/msol/msol.py
+++ b/plugins/msol/msol.py
@@ -102,6 +102,12 @@ def msol_authenticate(url, username, password, useragent, pluginargs):
                 data_response['output'] = f"[+] SUCCESS: {username}:{password} - NOTE: The user's password is expired."
                 data_response['valid_user'] = True
 
+            elif "AADSTS50057" in error:
+                # The user account is disabled
+                data_response['result'] = "success"
+                data_response['output'] = f"[+] SUCCESS: {username}:{password} - NOTE: The user is disabled."
+                data_response['valid_user'] = True
+                
             else:
                 # Unknown errors
                 data_response['result'] = "failure"


### PR DESCRIPTION
Handle AADSTS50057 error in the MSOL plugin. This error means that the password is valid, but the user is disabled. I'm returning a success code I don't know how you see this behavior we can change it.


- https://learn.microsoft.com/en-us/azure/active-directory/develop/reference-error-codes 