### PR TITLE
Exclude passwords from all notifications with exclude_password opt

### DIFF
--- a/credmaster.py
+++ b/credmaster.py
@@ -304,10 +304,15 @@ class CredMaster(object):
 					if self.userenum:
 						notify.notify_update("Info: Starting Userenum.", self.notify_obj)
 					else:
-						notify.notify_update(f"Info: Starting Spray.\nPass: {password}", self.notify_obj)
-
+						if self.notify_obj['exclude_password']:
+							notify.notify_update(f"Info: Starting Spray.", self.notify_obj)
+						else:
+							notify.notify_update(f"Info: Starting Spray.\nPass: {password}", self.notify_obj)
 				else:
-					notify.notify_update(f"Info: Spray Continuing.\nPass: {password}", self.notify_obj)
+					if self.notify_obj['exclude_password']:
+						notify.notify_update(f"Info: Spray Continuing.\nPassword #: {time_count}", self.notify_obj)
+					else:
+						notify.notify_update(f"Info: Spray Continuing.\nPass: {password}", self.notify_obj)
 
 				if self.weekdaywarrior is not None:
 					spray_days = {


### PR DESCRIPTION
The `exclude_password` option for excluding passwords from notifications still shows passwords at Spray start and Spray continuation allowing correct credentials to be inferred from message content from reading multiple messages - this PR fixes issue by also hiding passwords in these messages if `exclude_password` option set.