### PR TITLE
Allow early termination w/ --trim if all users validated

### DIFF
--- a/credmaster.py
+++ b/credmaster.py
@@ -328,6 +328,12 @@ class CredMaster(object):
 
 				self.load_credentials(password)
 
+				# Giving an early abort opportunity due to trim-ing out of all discovered usernames
+				if self.q_spray.qsize() < 1:
+					self.log_entry(f"Completing spray early due to all users being validated at {datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)}")
+					notify.notify_update(f"Info: Spray complete.", self.notify_obj)
+					break
+
 				# Start Spray
 				threads = []
 				for api in self.apis:


### PR DESCRIPTION
This prevents additional password sprays from being executed when the `--trim` option is specified and all users have already been validated - preventing program execution being unnecessarily extended when there are no more user/credential pairs to check